### PR TITLE
Set default values for collections entires 

### DIFF
--- a/src/helpers/updateDefaultValues.js
+++ b/src/helpers/updateDefaultValues.js
@@ -1,0 +1,17 @@
+function updateDefaultValues(obj, keyVal) {
+    Object.keys(obj).forEach((key) => {
+      let propValue = obj[key]
+        
+      if(propValue && typeof propValue === 'object') {
+          return updateDefaultValues(obj[key], keyVal)
+      }
+        
+      if (propValue === null && keyVal[key] !== undefined) {
+        obj[key] = keyVal[key]
+      }
+    })
+    
+    return obj
+  }
+  
+  module.exports = updateDefaultValues;


### PR DESCRIPTION
Many time when data is not complete its breaking the build since any field which needs a nested value if its set to `null` graphql will cry. This PR gives option to add some default value so you can still work and once data is available it will use those instead of default values.